### PR TITLE
docs: updated encrypted secrets deprecation messaging

### DIFF
--- a/docs/usage/mend-hosted/migrating-secrets.md
+++ b/docs/usage/mend-hosted/migrating-secrets.md
@@ -1,6 +1,6 @@
 # Migrating Secrets from Repo Config to App Settings
 
-On 01-Oct-2024 the Mend Renovate cloud apps will stop reading any encrypted secrets from the Renovate configuration file on your repository.
+Use of encrypted secrets in the Mend Renovate cloud apps has been deprecated and soon the apps will stop reading any encrypted secrets from the Renovate configuration file on your repository.
 Previously, you could encrypt a secret with the [Renovate encryption tool](https://app.renovatebot.com/encrypt) and then put it in your Renovate config file.
 
 Going forward, all secrets must be stored in the App settings on the cloud.


### PR DESCRIPTION
## Changes

Updated context on app secrets migration page to remove the expired deadline.

## Context

More time has been given to allow users to migrate encrypted secrets. So the migration docs page has been updated to reflect this.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository